### PR TITLE
Bug in RoomInSack?

### DIFF
--- a/lib/puny.h
+++ b/lib/puny.h
@@ -286,12 +286,11 @@ Constant ONE_SPACE_STRING = " ";
         for (_obj=youngest(player) : _obj : _obj=elder(_obj))
             if (_obj ~= SACK_OBJECT && _obj hasnt worn or light) {
                 _ks = keep_silent;
-                Keep_silent = 1;
+                keep_silent = 1;
                 <Insert _obj SACK_OBJECT>;
                 keep_silent = _ks;
-                if (keep_silent) return;
                 if (_obj in SACK_OBJECT) {
-					PrintMsg(MSG_SACK_PUTTING, _obj);
+                    if (keep_silent == 0) PrintMsg(MSG_SACK_PUTTING, _obj);
                     rtrue;
                 }
             }


### PR DESCRIPTION
If I understand correctly, RoomInSack is supposed to loop on all objects in the player's inventory and attempt to put one in the sack to make room in the inventory. It does that by trying to insert the object in the sack silently, and if it fails, it moves on to the next one.
However, with puny's current code, the routine abruptly exits after the first object if "keep_silent" is on; I feel like it should still keep trying with other objects in the hope that one will finally be inserted in the sack, even if nothing is supposed to be printed in the end. Unless I'm missing something?