### PR TITLE
Score notifications & Amusing

### DIFF
--- a/lib/puny.h
+++ b/lib/puny.h
@@ -1271,18 +1271,17 @@ Object thedark "Darkness"
 	else if(deadflag == GS_DEAD) PrintMsg(MSG_YOU_HAVE_DIED);
 	else if(deadflag >= GS_DEATHMESSAGE) DeathMessage();
 	print "  ***^";
-	for (::) {
+        for (::) {
 		PrintMsg(MSG_RESTART_RESTORE_OR_QUIT);
 		_ReadPlayerInput(true);
-		switch(parse-->1) {
-		'restart': @restart;
-		'restore': RestoreSub();
+                _i = parse-->1;
+                if (_i == 'restart') @restart;
+                if (_i == 'restore') RestoreSub();
+                if (AMUSING_PROVIDED == 0 && deadflag == 2 && _i == 'amusing') Amusing();
+                if (_i == 'quit') @quit;
 #IfDef OPTIONAL_FULL_SCORE;
-		'full': FullScoreSub();
+                if (_i == 'full') FullScoreSub();
 #EndIf;
-		'amusing': Amusing();
-		'quit': @quit;
-		}
 	}
 ];
 

--- a/lib/puny.h
+++ b/lib/puny.h
@@ -1243,12 +1243,9 @@ Object thedark "Darkness"
 		}
 
         if(deadflag == GS_PLAYING && _score < score && notify_mode == true) {
-        	print "^[The score has just gone up by ";
-        	if(score - _score == 1) {
-        		print "one point.]^";
-			} else {
-        		print score - _score, " points.]^";
-			}
+        	print "^[The score has just gone up by ", score - _score, " point";
+        	if(score - _score == 1) print "s";
+                print ".]^";
 		}
 
 		_parsearraylength = parse->1;


### PR DESCRIPTION
- Puny writes "The score has just gone up by one point." and "The score has just gone up by 2 points.". This should be more consistent. Saves 14 bytes, too.
- The "amusing" command was accessible to anyone who typed it (the message only advertises it if the game provides it and if the game ended in victory). I rewrote the switch to save space; this adds only 10 bytes.