### PR TITLE
Remove obsolete 6.36

### DIFF
--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -1,6 +1,6 @@
 v4.1: bug fix and new feature release
 
-- _CheckNoun routine has been made smaller and faster.
+- CheckNoun routine has been made smaller and faster.
 - Fixed a bug where patterns containing prepositions that didn't match
   at all didn't produce any response from the parser.
 - Allow author to define timer_order as a common property if they want, when

--- a/tests/largegame.inf
+++ b/tests/largegame.inf
@@ -1,5 +1,4 @@
 !% $OMIT_UNUSED_ROUTINES=1
-!% $MAX_STATIC_DATA=65000
 ! -- % -~S
 
 ! The very first lines of the main source code file for a game can

--- a/tests/test-parser.inf
+++ b/tests/test-parser.inf
@@ -1,8 +1,5 @@
 !% -~S
 !% $OMIT_UNUSED_ROUTINES=1
-!% $MAX_STATIC_DATA=60000
-!% $MAX_LABELS=5000
-!% $MAX_ZCODE_SIZE=50000
 
 Switches e;
 ! compile as z8 to use Inform stdlib instead of puny (for debugging)


### PR DESCRIPTION
Since PunyInform 4.0 requires at least Inform 6.36, the test games should no longer use the now obsolete memory settings: `MAX_STATIC_DATA`, `MAX_LABELS`, and `MAX_ZCODE_SIZE`.  This patch removes those usages.

This patch also removes a stray space in `releasenotes.txt`.