### PR TITLE
Replaced /bin/ruby shebang with /usr/bin/env ruby

### DIFF
--- a/tests/runtests.rb
+++ b/tests/runtests.rb
@@ -1,4 +1,4 @@
-#!/bin/ruby
+#!/usr/bin/env ruby
 
 $is_windows = (ENV['OS'] == 'Windows_NT')
 


### PR DESCRIPTION
Ruby could be installed in other places and this is a reliable way to automatically find it.