### PR TITLE
Moved declaration of version 2 grammar to AFTER Constant Grammar__Version = 2;

### DIFF
--- a/tests/test-parser.inf
+++ b/tests/test-parser.inf
@@ -74,20 +74,6 @@ Constant NUMBER_TASKS = 1;
 Constant MAX_SCORE = 3;
 #EndIf;
 
-[ Amusing;
-	"^Did you try?^^1. Pushing John many times.^2. Going outside and
-	looking at the sun";
-];
-
-! Setup cheap scenery
-[SceneryReply w1 w2;
-	Push:
-		if(w1=='bird' && w2=='birds') "The birds fly away as you try.";
-		"Now how would you do that?";
-	default:
-		rfalse;
-];
-
 
 ! Setup flags
 Constant FLAG_COUNT 8;
@@ -108,6 +94,20 @@ Include "Parser";
 Include "VerbLib";
 Include "../lib/ext_cheap_scenery.h";
 Include "../lib/ext_flags.h";
+
+[ Amusing;
+	"^Did you try?^^1. Pushing John many times.^2. Going outside and
+	looking at the sun";
+];
+
+! Setup cheap scenery
+[SceneryReply w1 w2;
+	Push:
+		if(w1=='bird' && w2=='birds') "The birds fly away as you try.";
+		"Now how would you do that?";
+	default:
+		rfalse;
+];
 
 [OnOff obj; ! TODO: is there something like this in I6? change name if needed
     if(obj has on) print "on";

--- a/tests/test-testbench.inf
+++ b/tests/test-testbench.inf
@@ -81,20 +81,6 @@ Constant NUMBER_TASKS = 1;
 Constant MAX_SCORE = 3;
 #EndIf;
 
-[ Amusing;
-	"^Did you try?^^1. Pushing John many times.^2. Going outside and looking at the sun";
-];
-
-! Setup cheap scenery
-[SceneryReply w1 w2;
-	Push:
-		if(w1=='bird' && w2=='birds') "The birds fly away as you try.";
-		"Now how would you do that?";
-	default:
-		rfalse;
-];
-
-
 ! Setup flags
 Constant FLAG_COUNT 8;
 !Constant F_SQUIRREL_ESCAPED 0;
@@ -110,6 +96,19 @@ Constant FLAG_COUNT 8;
 
 #Ifdef USEINFORM;
 Include "Parser";
+
+[ Amusing;
+	"^Did you try?^^1. Pushing John many times.^2. Going outside and looking at the sun";
+];
+
+! Setup cheap scenery
+[SceneryReply w1 w2;
+	Push:
+		if(w1=='bird' && w2=='birds') "The birds fly away as you try.";
+		"Now how would you do that?";
+	default:
+		rfalse;
+];
 
 Attribute reactive;
 


### PR DESCRIPTION
The Inform 6.43 code (in progress) imposed restrictions on how Grammar__Version may be set.  It no longer allows this to be done anywhere.  It MUST be done before any sort of action is done, otherwise the compiler will complain.

As a practical matter, no function should appear before the parser.h file is included.  That's what these changes do and should fix the problems I described in #119.

The commit in the Inform 6 codebase is this:
6a4de5b391379737831ac8ce2081a811c861b9a3