### PR TITLE
Fixed grammar rule for 'read topic in noun' not reversed

### DIFF
--- a/lib/grammar.h
+++ b/lib/grammar.h
@@ -145,7 +145,7 @@ Verb 'put' 'place'
 Verb 'read'
 	* noun                                      -> Examine
 	* 'about' topic 'in' noun                   -> Consult reverse
-	* topic 'in' noun                           -> Consult;
+	* topic 'in' noun                           -> Consult reverse;
 
 Verb 'remove'
 	* worn                                      -> Disrobe

--- a/tests/test-consult.cmd
+++ b/tests/test-consult.cmd
@@ -2,10 +2,12 @@ transcript
 
 consult book about ghosts
 read about ghosts in book
+read ghosts in book
 ask john about ghosts
 answer ghosts to john
 consult book about apple
 read about apple in book
+read apple in book
 ask john about apple
 answer apple to john
 quit

--- a/tests/test-consult.txt
+++ b/tests/test-consult.txt
@@ -11,6 +11,12 @@ consult_words = 1
 consult_from = 3
 You discover nothing of interest in the book.
 
+> read ghosts in book
+special_number = 0
+consult_words = 1
+consult_from = 2
+You discover nothing of interest in the book.
+
 > ask john about ghosts
 ???
 special_number = 0
@@ -35,6 +41,12 @@ You discover nothing of interest in the book.
 special_number = 0
 consult_words = 1
 consult_from = 3
+You discover nothing of interest in the book.
+
+> read apple in book
+special_number = 0
+consult_words = 1
+consult_from = 2
 You discover nothing of interest in the book.
 
 > ask john about apple


### PR DESCRIPTION
I'll admit I'm new to both PunyInform and inform6 in general, but the 3rd rule in the `read` grammar seems to be missing a `reversed`:

```
Verb 'read'
    * noun                            -> Examine
    * 'about' topic 'in' noun         -> Consult reverse
    * topic 'in' noun                 -> Consult;
```